### PR TITLE
add wilde-at-heart.garden (jlcolbert.github.io)

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -197,3 +197,7 @@
 - target: garden/the_one
   url: https://github.com/mnenoff/flancia01
   format: foam
+  
+- tagert: garden/wilde-at-heart
+  url: https://github.com/jlcolbert/jlcolbert.github.io.git
+  format: hugo

--- a/sources.yaml
+++ b/sources.yaml
@@ -198,6 +198,6 @@
   url: https://github.com/mnenoff/flancia01
   format: foam
   
-- tagert: garden/wilde-at-heart
+- target: garden/wilde-at-heart
   url: https://github.com/jlcolbert/jlcolbert.github.io.git
   format: hugo


### PR DESCRIPTION
I use Logseq for my garden and use the static site generator Hugo to publish it. I wasn't sure which to put as the format, so I put Hugo. Let me know if that's incorrect!

The published website is https://wilde-at-heart.garden/, with all pages being at [https://wilde-at-heart.garden/pages/{slug}](https://wilde-at-heart.garden/pages/%7Bslug%7D)