### PR TITLE
chore(sources): update entry for garden/ajhalili2006 and add garden/ajhalili2006-archive for old repo

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -253,7 +253,20 @@
   format: org
 
 - target: garden/ajhalili2006
-  url: https://mau.dev/andreijiroh.dev/digital-garden.git
+  url: https://mau.dev/andreijiroh-dev/wiki
+  # powered by mkdocs-material, baby
+  web: https://wiki.andreijiroh.xyz/{path}
+  edit: https://mau.dev/andreijiroh-dev/wiki/edit/main/{path}
+  # technically foam, although I may sometimes fire up Obsidian, formatting chaos
+  # are expected
+  format: foam
+
+- target: garden/ajhalili2006-old
+  url: https://mau.dev/ajhalili2006-archive/digital-garden.git
+  # these migration links will use Cloudflare Workers behind the scenes for
+  # redirection handling, but I may consider using Deno Deploy instead
+  web: https://wiki.andreijiroh.xyz/migrate/agora?path={path}
+  edit: https://wiki.andreijiroh.xyz/migrate/agora?path={path}&edit=1
   format: obsidian
 
 - target: garden/vera-journal


### PR DESCRIPTION
**BREAKING CHANGE**: Since this involve a change in repo URL and directory structure, it may break on old raw links when pointing to @ajhalili2006 via agora-styled wikilinks.

Also in this patch involves adding edit and web URLs finally and adding the old repo as a separate garden for historical purposes and to not break things (other than raw file links in `agora-server`)